### PR TITLE
[🐸 Frogbot] Update Gradle dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ apply plugin: 'java'
 apply plugin: 'maven-publish'
 
 dependencies {
-    testImplementation 'junit:junit:4.7'
+direct string fix
 }
 
 publishing {
@@ -70,3 +70,4 @@ artifactory {
         }
     }
 }
+


### PR DESCRIPTION
<div align='center'>

[![](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/vulnerabilitiesFixBannerPR.png)](https://github.com/jfrog/frogbot#readme)

</div>



## 📦 Vulnerable Dependencies 

### ✍️ Summary

<div align="center">

| SEVERITY                | CONTEXTUAL ANALYSIS                  | DIRECT DEPENDENCIES                  | IMPACTED DEPENDENCY                   | FIXED VERSIONS                       |
| :---------------------: | :----------------------------------: | :----------------------------------: | :-----------------------------------: | :---------------------------------: | 
| ![](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/applicableMediumSeverity.png)<br>  Medium | Undetermined | junit:junit:4.7 | junit:junit:4.7 | [4.13.1] |

</div>

## 👇 Details




- **Severity** 🎃 Medium
- **Contextual Analysis:** Undetermined
- **Package Name:** junit:junit
- **Current Version:** 4.7
- **CVE:** CVE-2020-15250
- **Fixed Version:** [4.13.1]

**Description:**

In JUnit4 from version 4.7 and before 4.13.1, the test rule TemporaryFolder contains a local information disclosure vulnerability. On Unix like systems, the system's temporary directory is shared between all users on that system. Because of this, when files and directories are written into this directory they are, by default, readable by other users on that same system. This vulnerability does not allow other users to overwrite the contents of these directories or files. This is purely an information disclosure vulnerability. This vulnerability impacts you if the JUnit tests write sensitive information, like API keys or passwords, into the temporary folder, and the JUnit tests execute in an environment where the OS has other untrusted users. Because certain JDK file system APIs were only added in JDK 1.7, this this fix is dependent upon the version of the JDK you are using. For Java 1.7 and higher users: this vulnerability is fixed in 4.13.1. For Java 1.6 and lower users: no patch is available, you must use the workaround below. If you are unable to patch, or are stuck running on Java 1.6, specifying the `java.io.tmpdir` system environment variable to a directory that is exclusively owned by the executing user will fix this vulnerability. For more information, including an example of vulnerable code, see the referenced GitHub Security Advisory.




---

<div align="center">

[JFrog Frogbot](https://github.com/jfrog/frogbot#readme)

</div>

[comment]: <> (Checksum: 97468299b4e22d30047698ed33dba845)
