### PR TITLE
[🐸 Frogbot] Update Gradle dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,8 +39,8 @@ apply plugin: 'maven-publish'
 
 dependencies {
     implementation("junit:junit:[4.0, 4.9]")
-    implementation("commons-io:commons-io:latest.release")
-    implementation("commons-collections:commons-collections:3.2@jar")
+    implementation("commons-io:commons-io:2.7")
+    implementation("commons-collections:commons-collections:3.2.2@jar")
 
 }
 


### PR DESCRIPTION
<div align='center'>

[![](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/vulnerabilitiesFixBannerPR.png)](https://github.com/jfrog/frogbot#readme)

</div>



## 📦 Vulnerable Dependencies 

### ✍️ Summary

<div align="center">

| SEVERITY                | CONTEXTUAL ANALYSIS                  | DIRECT DEPENDENCIES                  | IMPACTED DEPENDENCY                   | FIXED VERSIONS                       |
| :---------------------: | :----------------------------------: | :----------------------------------: | :-----------------------------------: | :---------------------------------: | 
| ![](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/applicableCriticalSeverity.png)<br>Critical | Undetermined | commons-collections:commons-collections:3.2 | commons-collections:commons-collections:3.2 | [3.2.2] |
| ![](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/notApplicableMedium.png)<br>  Medium | Not Applicable | commons-io:commons-io:latest.release | commons-io:commons-io:latest.release | [2.7] |

</div>

## 👇 Details


<details>
<summary> <b>commons-collections:commons-collections 3.2</b> </summary>
<br>

- **Severity** 💀 Critical
- **Contextual Analysis:** Undetermined
- **Package Name:** commons-collections:commons-collections
- **Current Version:** 3.2
- **Fixed Version:** [3.2.2]

**Description:**

The Apache Commons Collections library contains various classes in the "functor" package which are serializable and use reflection. This can be exploited for remote code execution attacks by injecting specially crafted objects to applications that de-serialize java objects from untrusted sources and have the Apache Commons Collections library in their classpath and do not perform any kind of input validation.



</details>


<details>
<summary> <b>[ CVE-2021-29425 ] commons-io:commons-io latest.release</b> </summary>
<br>

- **Severity** 🎃 Medium
- **Contextual Analysis:** Not Applicable
- **Package Name:** commons-io:commons-io
- **Current Version:** latest.release
- **CVE:** CVE-2021-29425
- **Fixed Version:** [2.7]

**Description:**

In Apache Commons IO before 2.7, When invoking the method FileNameUtils.normalize with an improper input string, like "//../foo", or "\\..\foo", the result would be the same value, thus possibly providing access to files in the parent directory, but not further above (thus "limited" path traversal), if the calling code would use the result to construct a path value.



</details>


---

<div align="center">

[JFrog Frogbot](https://github.com/jfrog/frogbot#readme)

</div>

[comment]: <> (Checksum: 862d991042a0b0c62cec77e4d5c5e1e0)
