### PR TITLE
[🐸 Frogbot] Update Gradle dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ apply plugin: 'java'
 apply plugin: 'maven-publish'
 
 dependencies {
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.10.1'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.12.7.1'
 
 }
 


### PR DESCRIPTION
<div align='center'>

[![](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/vulnerabilitiesFixBannerPR.png)](https://github.com/jfrog/frogbot#readme)

</div>



## 📦 Vulnerable Dependencies 

### ✍️ Summary

<div align="center">

| SEVERITY                | CONTEXTUAL ANALYSIS                  | DIRECT DEPENDENCIES                  | IMPACTED DEPENDENCY                   | FIXED VERSIONS                       |
| :---------------------: | :----------------------------------: | :----------------------------------: | :-----------------------------------: | :---------------------------------: | 
| ![](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/applicableHighSeverity.png)<br>    High | Undetermined | com.fasterxml.jackson.core:jackson-databind:2.10.1 | com.fasterxml.jackson.core:jackson-databind:2.10.1 | [2.12.7.1]<br><br>[2.13.4] |

</div>

## 👇 Details




- **Severity** 🔥 High
- **Contextual Analysis:** Undetermined
- **Package Name:** com.fasterxml.jackson.core:jackson-databind
- **Current Version:** 2.10.1
- **CVE:** CVE-2020-36518
- **Fixed Versions:** [2.12.7.1],[2.13.4]

**Description:**

[Jackson-databind](https://github.com/FasterXML/jackson-databind) is a streaming API library for Java. One of its components, `ObjectMapper`, is responsible for serialization and deserialization of Java objects.

It was discovered that the `UntypedObjectDeserializer` is expensive for deeply nested Objects and Arrays, which quickly leads to massive memory consumption and denial of service.

To exploit this issue, an attacker must be able to supply an arbitrary serialized input (a deeply nested object) to the `readValue` API. In addition, the `readValue` API call must map the output to an untyped object such as `Object` or `Map<String, Object>`. 

Example of a vulnerable code snippet -
`objMapper.readValue(userInput, Object.class);`




---

---
<div align="center">

[🐸 JFrog Frogbot](https://github.com/jfrog/frogbot#readme)

</div>

[comment]: <> (Checksum: deda76f3c798bfbbd6e89e1c6fc9c82b)
