### PR TITLE
[🐸 Frogbot] Update Gradle dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,32 +38,32 @@ apply plugin: 'java'
 apply plugin: 'maven-publish'
 
 dependencies {
-    testImplementation 'junit:junit:4.7' // simple string with ''
-    implementation "junit:junit:4.7" // simple string with ""
-    implementation 'junit:junit:4.7:javadoc' // string with extra args after version
-    implementation('junit:junit:4.7') // with ()
+    testImplementation 'junit:junit:4.13.1' // simple string with ''
+    implementation "junit:junit:4.13.1" // simple string with ""
+    implementation 'junit:junit:4.13.1:javadoc' // string with extra args after version
+    implementation('junit:junit:4.13.1') // with ()
 
-    implementation group: 'junit', name: 'junit', version: '4.7' // map with ''
-    implementation group: "junit", name: "junit", version: "4.7" // map with ""
-    implementation group: 'junit', name: 'junit', version: '4.7', classifier: 'javadoc' // map with extra entries after version
-    implementation(group: 'junit', name: 'junit', version: '4.7', classifier: 'javadoc') // with ()
+    implementation group: 'junit', name: 'junit', version: '4.13.1' // map with ''
+    implementation group: "junit", name: "junit", version: "4.13.1" // map with ""
+    implementation group: 'junit', name: 'junit', version: '4.13.1', classifier: 'javadoc' // map with extra entries after version
+    implementation(group: 'junit', name: 'junit', version: '4.13.1', classifier: 'javadoc') // with ()
     implementation(group: 'commons-collections', name: 'commons-collections', version: '3.+')
 
 
-    implementation 'junit:junit:4.7',
-            'commons-io:commons-io:1.2'
+    implementation 'junit:junit:4.13.1',
+            'commons-io:commons-io:2.7'
 
     implementation(
-            group: 'commons-io', name: 'commons-io', version: '1.2'
+            group: 'commons-io', name: 'commons-io', version: '2.7'
     )
 
-    implementation("commons-io:commons-io:1.2") {
+    implementation("commons-io:commons-io:2.7") {
         exclude module: "MyHartaModule"
     }
 
     implementation(
-            [group: 'commons-io', name: 'commons-io', version: '1.2'],
-            ['commons-io:commons-io:1.2']
+            [group: 'commons-io', name: 'commons-io', version: '2.7'],
+            ['commons-io:commons-io:2.7']
     )
 
 }

--- a/innerProject/build.gradle.kts
+++ b/innerProject/build.gradle.kts
@@ -3,17 +3,17 @@ val spi: Configuration by configurations.creating
 dependencies {
     implementation(project(":project"))
 
-    runtimeOnly('junit:junit:4.7')
-    runtimeOnly("junit:junit:4.7")
-    implementation('junit:junit:4.7:javadoc')
-    runtimeOnly("commons-io:commons-io:1.2") {
+    runtimeOnly('junit:junit:4.13.1')
+    runtimeOnly("junit:junit:4.13.1")
+    implementation('junit:junit:4.13.1:javadoc')
+    runtimeOnly("commons-io:commons-io:2.7") {
         isTransitive = true
     }
 
-    runtimeOnly(group = 'junit', name = 'junit', version = '4.7')
-    runtimeOnly(group = "junit", name = "junit", version = "4.7")
-    runtimeOnly(group = 'junit', name = 'junit', version = '4.7', classifier = 'javadoc')
-    runtimeOnly(group = "commons-io", name = "commons-io", version = "1.2") {
+    runtimeOnly(group = 'junit', name = 'junit', version = '4.13.1')
+    runtimeOnly(group = "junit", name = "junit", version = "4.13.1")
+    runtimeOnly(group = 'junit', name = 'junit', version = '4.13.1', classifier = 'javadoc')
+    runtimeOnly(group = "commons-io", name = "commons-io", version = "2.7") {
         isTransitive = true
     }
 }


### PR DESCRIPTION
<div align='center'>

[![](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/vulnerabilitiesFixBannerPR.png)](https://github.com/jfrog/frogbot#readme)

</div>



## 📦 Vulnerable Dependencies 

### ✍️ Summary

<div align="center">

| SEVERITY                | CONTEXTUAL ANALYSIS                  | DIRECT DEPENDENCIES                  | IMPACTED DEPENDENCY                   | FIXED VERSIONS                       |
| :---------------------: | :----------------------------------: | :----------------------------------: | :-----------------------------------: | :---------------------------------: | 
| ![](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/applicableMediumSeverity.png)<br>  Medium | Undetermined | junit:junit:4.7 | junit:junit:4.7 | [4.13.1] |
| ![](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/applicableMediumSeverity.png)<br>  Medium | Undetermined | commons-io:commons-io:1.2 | commons-io:commons-io:1.2 | [2.7] |

</div>

## 👇 Details


<details>
<summary> <b>[ CVE-2020-15250 ] junit:junit 4.7</b> </summary>
<br>

- **Severity** 🎃 Medium
- **Contextual Analysis:** Undetermined
- **Package Name:** junit:junit
- **Current Version:** 4.7
- **CVE:** CVE-2020-15250
- **Fixed Version:** [4.13.1]

**Description:**

In JUnit4 from version 4.7 and before 4.13.1, the test rule TemporaryFolder contains a local information disclosure vulnerability. On Unix like systems, the system's temporary directory is shared between all users on that system. Because of this, when files and directories are written into this directory they are, by default, readable by other users on that same system. This vulnerability does not allow other users to overwrite the contents of these directories or files. This is purely an information disclosure vulnerability. This vulnerability impacts you if the JUnit tests write sensitive information, like API keys or passwords, into the temporary folder, and the JUnit tests execute in an environment where the OS has other untrusted users. Because certain JDK file system APIs were only added in JDK 1.7, this this fix is dependent upon the version of the JDK you are using. For Java 1.7 and higher users: this vulnerability is fixed in 4.13.1. For Java 1.6 and lower users: no patch is available, you must use the workaround below. If you are unable to patch, or are stuck running on Java 1.6, specifying the `java.io.tmpdir` system environment variable to a directory that is exclusively owned by the executing user will fix this vulnerability. For more information, including an example of vulnerable code, see the referenced GitHub Security Advisory.



</details>


<details>
<summary> <b>[ CVE-2021-29425 ] commons-io:commons-io 1.2</b> </summary>
<br>

- **Severity** 🎃 Medium
- **Contextual Analysis:** Undetermined
- **Package Name:** commons-io:commons-io
- **Current Version:** 1.2
- **CVE:** CVE-2021-29425
- **Fixed Version:** [2.7]

**Description:**

In Apache Commons IO before 2.7, When invoking the method FileNameUtils.normalize with an improper input string, like "//../foo", or "\\..\foo", the result would be the same value, thus possibly providing access to files in the parent directory, but not further above (thus "limited" path traversal), if the calling code would use the result to construct a path value.



</details>


---

---
<div align="center">

[🐸 JFrog Frogbot](https://github.com/jfrog/frogbot#readme)

</div>

[comment]: <> (Checksum: 77f3693ba8f70da571ea0583b99f9a94)
